### PR TITLE
Rule UI for text inference with interactive component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.0.7] - 2022-08-26
 
 - Lex fulfilment Lambda that captures the full lex response to state
+
+## [3.0.8] - 2022-08-30
+
+- Text inference rule that can take text including the results from previous voice lex bots and perform additional inferencing
+
+

--- a/lambda/InteractiveInference.js
+++ b/lambda/InteractiveInference.js
@@ -23,6 +23,7 @@ const queueInteractive = require('./interactive/Queue');
 const ruleSetInteractive = require('./interactive/RuleSet');
 const smsMessageInteractive = require('./interactive/SMSMessage');
 const setAttributesInteractive = require('./interactive/SetAttributes');
+const textInferenceInteractive = require('./interactive/TextInference');
 const terminateInteractive = require('./interactive/Terminate');
 const updateStatesInteractive = require('./interactive/UpdateStates');
 
@@ -381,6 +382,11 @@ async function handleExecute(context)
       case 'UpdateStates':
       {
         response = await updateStatesInteractive.execute(context);
+        break;
+      }
+      case 'TextInference':
+      {
+        response = await textInferenceInteractive.execute(context);
         break;
       }
       case 'Terminate':

--- a/lambda/interactive/TextInference.js
+++ b/lambda/interactive/TextInference.js
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TextInference interactive rule component definition exposing the following
+ * lifecycle methods:
+ *
+ * execute() called on first invocation (required)
+ * input() called after input on provided (optional)
+ * confirm() called after confirmation is provided (optional)
+ *
+ * The context parameter contains:
+ *
+ *  - requestMessage: the current request message
+ *  - currentRuleSet: the current rule set
+ *  - currentRule: the current rule
+ *  - customerState: the current customer state
+ *  - stateToSave: A set containing the state fields to persist
+ */
+
+var inferenceUtils = require('../utils/InferenceUtils');
+var commonUtils = require('../utils/CommonUtils');
+var lexUtils = require('../utils/LexUtils');
+var configUtils = require('../utils/ConfigUtils');
+var handlebarsUtils = require('../utils/HandlebarsUtils');
+
+/**
+ * Executes TextInference interactive rule which allows
+ * determining a target rule set based on a matched intent
+ * with a confidence threshold.
+ * This is designed as an unattended rule, it will either match
+ * an intent with a threshold or will fall through to the next rule.
+ * execute() takes an input text payload and inferences the configured bot,
+ * looking for intent matches that reach a threshold confidence.
+ * The lex response is written to the customer's state under LexResponses.<bot name>.
+ * for additional inspection.
+ */
+module.exports.execute = async (context) =>
+{
+  try
+  {
+    // Perform context validation
+    validateContext(context);
+
+    var input = context.customerState.CurrentRule_input;
+    var lexBotName = context.customerState.CurrentRule_lexBotName;
+
+    var lexBot = await module.exports.findLexBot(lexBotName);
+
+    var intentResponse = await inferenceLexBot(lexBot, input, context.requestMessage.contactId);
+
+    console.info(`Got lex intent response: ${JSON.stringify(intentResponse, null, 2)}`);
+
+    var nextRuleSet = context.customerState['CurrentRule_intentRuleSet_' + intentResponse.intent];
+
+    if (!commonUtils.isEmptyString(nextRuleSet))
+    {
+      var intentConfidence = 0.0;
+
+      if (commonUtils.isNumber(context.customerState['CurrentRule_intentConfidence_' + intentResponse.intent]))
+      {
+        intentConfidence = +context.customerState['CurrentRule_intentConfidence_' + intentResponse.intent];
+      }
+
+      if (intentResponse.confidence >= intentConfidence)
+      {
+        console.info(`Reached required confidence: ${intentConfidence} with confidence: ${intentResponse.confidence} for intent: ${intentResponse.intent} routing to rule set: ${nextRuleSet}`)
+        inferenceUtils.updateStateContext(context, 'NextRuleSet', nextRuleSet);
+      }
+      else
+      {
+        console.info(`Did not reach required confidence: ${intentConfidence} with confidence: ${intentResponse.confidence} for intent: ${intentResponse.intent} routing to rule set: ${nextRuleSet}`)
+      }
+    }
+    else
+    {
+      console.info(`Found no rule set mapping for intent: ${intentResponse.intent} falling through`);
+    }
+
+    return {
+      contactId: context.requestMessage.contactId,
+      inputRequired: false,
+      ruleSet: context.currentRuleSet.name,
+      rule: context.currentRule.name,
+      ruleType: context.currentRule.type,
+    };
+  }
+  catch (error)
+  {
+    console.error('TextInference.execute() failed', error);
+    throw error;
+  }
+};
+
+/**
+ * Executes TextInference input
+ */
+module.exports.input = async (context) =>
+{
+  console.error('TextInference.input() is not implemented');
+  throw new Error('TextInference.input() is not implemented');
+};
+
+/**
+ * Executes TextInference confirm
+ */
+module.exports.confirm = async (context) =>
+{
+  console.error('TextInference.confirm() is not implemented');
+  throw new Error('TextInference.confirm() is not implemented');
+};
+
+/**
+ * Validates the context
+ */
+function validateContext(context)
+{
+  console.info(`TextInference.validateContext() context: ${JSON.stringify(context, null, 2)}`);
+
+  if (context.requestMessage === undefined ||
+      context.customerState === undefined ||
+      context.currentRuleSet === undefined ||
+      context.currentRule === undefined ||
+      context.customerState.CurrentRule_input === undefined ||
+      context.customerState.CurrentRule_lexBotName === undefined)
+  {
+    throw new Error('TextInference has invalid configuration');
+  }
+}
+
+/**
+ * Locates a lex bot by simple name or throws
+ */
+module.exports.findLexBot = async (lexBotName) =>
+{
+  var lexBots = await configUtils.getLexBots(process.env.CONFIG_TABLE);
+  var lexBot = lexBots.find(lexBot => lexBot.SimpleName === lexBotName);
+
+  if (lexBot === undefined)
+  {
+    throw new Error('NLUInput.findLexBot() could not find Lex bot: ' + lexBotName);
+  }
+
+  console.info('Found lex bot: ' + JSON.stringify(lexBotName, null, 2));
+
+  return lexBot;
+};
+
+/**
+ * Inferences a lex bot using recognizeText()
+ */
+async function inferenceLexBot(lexBot, input, contactId)
+{
+  return await lexUtils.recognizeText(lexBot.Id, lexBot.AliasId, lexBot.LocaleId, input, contactId);
+}

--- a/lambda/utils/ConnectUtils.js
+++ b/lambda/utils/ConnectUtils.js
@@ -55,7 +55,8 @@ module.exports.nonConnectActionTypes = [
   'Distribution',
   'Metric',
   'UpdateStates',
-  'SetAttributes'
+  'SetAttributes',
+  'TextInference'
 ];
 
 /**

--- a/lambda/utils/LexUtils.js
+++ b/lambda/utils/LexUtils.js
@@ -245,7 +245,8 @@ module.exports.recognizeText = async (botId, aliasId, localeId, text, sessionId 
     return {
       intent: interpretation.intent.name,
       confidence: score,
-      slots: interpretation.intent.slots
+      slots: interpretation.intent.slots,
+      lexResponse: inferenceResponse
     };
   }
   catch (error)

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -27,7 +27,7 @@ custom:
   instanceArn: ${env:instanceArn, 'CHANGEME'}
   outboundNumber: ${env:outboundNumber, 'CHANGEME'}
   environmentName: ${env:environmentName, 'Unknown'}
-  deployVersion: ${env:deployVersion, '3.0.7 (Lex fulfillment)'}
+  deployVersion: ${env:deployVersion, '3.0.8 (Text inference)'}
   callCentreTimeZone: ${env:callCentreTimeZone, 'Australia/Melbourne'}
   botAlias: ${env:botAlias, 'PROD'}
   botLocaleId: ${env:botLocaleId, 'en_AU'}

--- a/test/GenericRequireLoaderTest.js
+++ b/test/GenericRequireLoaderTest.js
@@ -108,5 +108,6 @@ describe('It should require all testable files in the project to check covrage!'
         require("../lambda/interactive/SetAttributes.js")
         require("../lambda/interactive/SMSMessage.js")
         require("../lambda/interactive/Terminate.js")
+        require("../lambda/interactive/TextInference.js")
         require("../lambda/interactive/UpdateStates.js")
 });

--- a/test/interactive/NLUInputTest.js
+++ b/test/interactive/NLUInputTest.js
@@ -1,13 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const rewire = require('rewire');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AWSMock = require('aws-sdk-mock');
 const interactiveConfig = require('./InteractiveConfig');
 const lexRuntimeV2Mocker = require('../utils/LexRuntimeV2Mocker');
-const nluInputInteractive = rewire('../../lambda/interactive/NLUInput');
+const nluInputInteractive = require('../../lambda/interactive/NLUInput');
 const configUtils = require('../../lambda/utils/ConfigUtils');
 const lexUtils = require('../../lambda/utils/LexUtils');
 

--- a/test/interactive/TextInferenceTest.js
+++ b/test/interactive/TextInferenceTest.js
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const AWSMock = require('aws-sdk-mock');
+const lexRuntimeV2Mocker = require('../utils/LexRuntimeV2Mocker');
+const interactiveConfig = require('./InteractiveConfig');
+const textInferenceInteractive = require('../../lambda/interactive/TextInference');
+const configUtils = require('../../lambda/utils/ConfigUtils');
+const lexUtils = require('../../lambda/utils/LexUtils');
+
+/**
+ * TextInference tests
+ */
+describe('TextInferenceTests', function()
+{
+  this.beforeAll(function()
+  {
+    interactiveConfig.loadEnv();
+
+    // Mock lex bot interactions
+    lexRuntimeV2Mocker.setupMockLexRuntimeV2(AWSMock, lexUtils);
+
+    var getLexBots = sinon.fake.returns([
+      {
+        "Name": "unittesting-rules-engine-date",
+        "SimpleName": "date",
+        "Arn": "arn:aws:lex:ap-southeast-2:55555555:bot-alias/A9EYOXQ8FF/E8SEC9JHHC",
+        "Id": "A9EYOXQ8FF",
+        "LocaleId": "en_AU",
+        "AliasId": "E8SEC9JHHC"
+      },
+      {
+        "Name": "unittesting-rules-engine-yesno",
+        "SimpleName": "yesno",
+        "Arn": "arn:aws:lex:ap-southeast-2:55555555:bot-alias/A9EYOXQ8TT/E8SEC9JHLP",
+        "Id": "A9EYOXQ8TT",
+        "LocaleId": "en_AU",
+        "AliasId": "E8SEC9JHLP"
+      },
+      {
+        "Name": "unittesting-rules-engine-intent",
+        "SimpleName": "intent",
+        "Arn": "arn:aws:lex:ap-southeast-2:55555555:bot-alias/A9EYOXQ8FF/GGSEC9JHLP",
+        "Id": "A9EYOXQ8FF",
+        "LocaleId": "en_AU",
+        "AliasId": "GGSEC9JHLP"
+      }
+    ]);
+
+    sinon.replace(configUtils, 'getLexBots', getLexBots);
+  });
+
+  this.afterAll(function()
+  {
+    sinon.restore();
+    AWSMock.restore('LexRuntimeV2');
+  });
+
+  // Tests vanilla routing handler should fail with invalid context
+  it('TextInference.handler() vanilla routing handler', async function()
+  {
+    var context = makeTestContext();
+
+    var response = await textInferenceInteractive.execute(context);
+
+    expect(response.message).to.equal(undefined);
+    expect(response.inputRequired).to.equal(false);
+    expect(response.contactId).to.equal('test-textinference-rule');
+    expect(response.ruleSet).to.equal('My text inference ruleset');
+    expect(response.rule).to.equal('My text inference rule');
+    expect(response.ruleType).to.equal('TextInference');
+    expect(response.audio).to.equal(undefined);
+    expect(context.stateToSave.size).to.equal(1);
+
+    expect(context.stateToSave.has('NextRuleSet')).to.equal(true);
+    expect(context.customerState.NextRuleSet).to.equal('Technical support ruleset');
+  });
+});
+
+/**
+ * Makes a test context
+ */
+function makeTestContext()
+{
+  return {
+    requestMessage: {
+      contactId: 'test-textinference-rule',
+      generateVoice: false
+    },
+    currentRuleSet: {
+      name: 'My text inference ruleset'
+    },
+    currentRule: {
+      name: 'My text inference rule',
+      type: 'TextInference',
+      params: {
+      }
+    },
+    customerState: {
+      CurrentRule_input: 'I have a technical support question',
+      CurrentRule_lexBotName: 'intent',
+      CurrentRule_intentRuleSet_TechnicalSupport: 'Technical support ruleset',
+      CurrentRule_intentConfidence_TechnicalSupport: '0.8',
+      CurrentRule_intentRuleSet_FalbackIntent: 'Fallback ruleset',
+      System: {}
+    },
+    stateToSave: new Set()
+  };
+}

--- a/test/utils/LexRuntimeV2Mocker.js
+++ b/test/utils/LexRuntimeV2Mocker.js
@@ -10,7 +10,7 @@ module.exports.setupMockLexRuntimeV2 = function (AWSMock, lexUtils)
 {
   AWSMock.mock('LexRuntimeV2', 'recognizeText', (function (params, callback)
   {
-    if (params.text === 'Technical support')
+    if (params.text.toLowerCase().includes('technical support'))
     {
       callback(null, makeMatchedIntentResponse('TechnicalSupport', 0.8));
     }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -75,19 +75,7 @@ function clearAllToasts()
  */
 function isNumber(value)
 {
-  if (value === undefined ||
-      value === null ||
-      value === '' ||
-      value === true ||
-      value === false ||
-      isNaN(value))
-  {
-    return false;
-  }
-  else
-  {
-    return true;
-  }
+  return !isNaN(parseFloat(value)) && isFinite(value);
 }
 
 /**
@@ -1114,6 +1102,8 @@ window.addEventListener('load', async () =>
           window.location.hash = '#configure';
           return;
         }
+
+        console.info(`Loaded rule: ${JSON.stringify(rule, null, 2)}`);
 
         var ruleSetsNames = [];
         var ruleSetsNameId = [];
@@ -4173,6 +4163,7 @@ function getValidActionNames()
     'SetAttributes',
     'SMSMessage',
     'Terminate',
+    'TextInference',
     'UpdateStates'
   ];
 }

--- a/web/templates/configureRule.hbs
+++ b/web/templates/configureRule.hbs
@@ -1021,6 +1021,49 @@
       </div>
 
       <!--
+        TextInference
+      -->
+      <div id="CreateTextInferenceDiv" class="createDiv">
+        <p>
+          The TextInference rule inferences a LexV2 bot with text to determine
+          the next rule set. The intent must match with a minimum confidence or the rule
+          fall through to the next rule.
+        </p>
+        <p>
+          Input message is often source from the input transcript of previous Lex bot inferencing but may be sourced from anywhere in customer state.
+        </p>
+        <p>
+          You may also optionally match the FallbackIntent
+          for the bot in which case, intent match failures will always route to
+          the configured FallbackIntent this rule set.
+        </p>
+        <div class="form-group">
+          <label>Input message *</label>
+          <input type="text"
+            class="form-control"
+            id="textInferenceInput"
+            maxLength="1024"
+            placeholder="&#123;&#123;&#123;LexResponses.botname.inputTranscript&#125;&#125;&#125;"
+            value="{{rule.params.input}}">
+          <small>Enter the text or template to inference against (usually obtained from a previous bot's input transcript)</small>
+        </div>
+        <div class="form-group">
+          <label>Lex bot *</label>
+          <select id="textInferenceLexBotName" title="Choose a bot" class="selectpicker form-control" data-style="btn-white" data-live-search="true">
+            {{#each lexBots}}
+              <option {{#ifeq this.SimpleName ../rule.params.lexBotName}}selected{{/ifeq}}>{{this.SimpleName}}</option>
+            {{/each}}
+          </select>
+          <small>The Lex bot to use for text inferencing</small>
+        </div>
+
+        <div class="form-group">
+          <label>Optionally choose a ruleset and intent confidence for each intent</label>
+          <div id="textInferenceLexIntents"></div>
+        </div>
+      </div>
+
+      <!--
         UpdateStates
       -->
       <div id="CreateUpdateStatesDiv" class="createDiv">
@@ -1393,7 +1436,16 @@
   $('#nluMenuLexBotName').on('change', function(e)
   {
     var lexBotName = $('#nluMenuLexBotName').val();
-    loadIntents(lexBotName);
+    loadIntentsNLUMenu(lexBotName);
+  });
+
+  /**
+   * Fired when the lex bot is changed
+   */
+  $('#textInferenceLexBotName').on('change', function(e)
+  {
+    var lexBotName = $('#textInferenceLexBotName').val();
+    loadIntentsTextInference(lexBotName);
   });
 
   /**
@@ -2993,6 +3045,74 @@
     }
 
     /**
+     * TextInference
+     */
+    if (ruleType === 'TextInference')
+    {
+      if (currentBot === undefined)
+      {
+        alert('No bot was loaded');
+        return;
+      }
+
+      var botName = $('#textInferenceLexBotName').val().trim();
+      var input = $('#textInferenceInput').val().trim();
+
+      if (botName === '')
+      {
+        alert('Please select a lex bot');
+        return;
+      }
+
+      if (input === '')
+      {
+        alert('Please enter an input message template');
+        return;
+      }
+
+      params.input = input;
+      params.lexBotName = currentBot.botName;
+      var intentCount = 0;
+
+      // Check each intent has a rule set and a confirmation message
+      for (var intentIndex = 0; intentIndex < currentBot.intents.length; intentIndex++)
+      {
+        var intent = currentBot.intents[intentIndex];
+
+        var ruleSetName = $(`#textInferenceIntentRuleSet_${intent.intentName}`).val().trim();
+        var confidence = $(`#textInferenceIntentConfidence_${intent.intentName}`).val().trim();
+
+        if (ruleSetName !== '')
+        {
+          if (confidence === '' ||
+             !isNumber(confidence) ||
+             +confidence < 0.0 ||
+             +confidence > 1.0)
+          {
+            alert(`Please enter a valid confidence for intent: ${intent.intentName} between 0.0 and 1.0`);
+            return;
+          }
+
+          params[`intentRuleSet_${intent.intentName}`] = ruleSetName;
+          params[`intentConfidence_${intent.intentName}`] = confidence;
+          intentCount++;
+        }
+      }
+
+      var fallBackIntentRuleSet = $(`#textInferenceIntentRuleSet_FallbackIntent`).val().trim();
+
+      if (fallBackIntentRuleSet !== '')
+      {
+        params[`intentRuleSet_FallbackIntent`] = fallBackIntentRuleSet;
+        intentCount++;
+      }
+
+      params.intentCount = '' + intentCount;
+
+      console.log('[INFO] made TextInference params: ' + JSON.stringify(params, null, 2));
+    }
+
+    /**
      * UpdateStates
      */
     if (ruleType === 'UpdateStates')
@@ -3089,7 +3209,13 @@
     if (ruleType === 'NLUMenu' && $('#nluMenuLexBotName').val().trim() !== '')
     {
       var lexBotName = $('#nluMenuLexBotName').val().trim();
-      loadIntents(lexBotName);
+      loadIntentsNLUMenu(lexBotName);
+    }
+
+    if (ruleType === 'TextInference' && $('#textInferenceLexBotName').val().trim() !== '')
+    {
+      var lexBotName = $('#textInferenceLexBotName').val().trim();
+      loadIntentsTextInference(lexBotName);
     }
 
     if (ruleType === 'RuleSetPrompt')
@@ -3186,7 +3312,90 @@
   // The currently selected lex bot
   var currentBot = undefined;
 
-  async function loadIntents(lexBotName)
+  async function loadIntentsTextInference(lexBotName)
+  {
+    $('#textInferenceLexIntents').html(`<div class="text-center"><img src="img/loading.gif" class="img-fluid" alt="Loading..."></div>`);
+
+    currentBot = await describeLexBot(lexBotName);
+
+    var html = '';
+
+    currentBot.intents.forEach(intent => {
+
+      var existingRuleSetName = loadedRule.params['intentRuleSet_' + intent.intentName];
+      var existingConfidence = loadedRule.params['intentConfidence_' + intent.intentName];
+
+      if (existingConfidence === undefined)
+      {
+        existingConfidence = '1.0';
+      }
+
+      html +=
+        `<hr><div class="row pb-1 px-3">` +
+          `<div class="col-4">${intent.intentName}</div>` +
+          `<div class="col-8"><label for="textInferenceIntentRuleSet_${intent.intentName}">Pick an optional target rule set</label>` +
+            `<div class="row"><div class="col-11">` +
+              `<select class="selectpicker form-control" title="Choose a rule set" data-style="btn-white" data-live-search="true" id="textInferenceIntentRuleSet_${intent.intentName}">` +
+                `<option></option>`;
+
+                ruleSetsNames.forEach(rsn => {
+                  if (rsn === existingRuleSetName)
+                  {
+                    html += `<option selected>${rsn}</option>`;
+                  }
+                  else
+                  {
+                    html += `<option>${rsn}</option>`;
+                  }
+                });
+
+            html +=
+              `</select></div>` +
+              `<div class="col-1">` +
+                `<a href="javascript:viewRuleSet('#textInferenceIntentRuleSet_${intent.intentName}');"><i class="fas fa-chevron-circle-right fa-lg text-primary mt-2"></i></a>` +
+              `</div></div>` +
+            `<label class="pt-2" for="textInferenceIntentConfidence_${intent.intentName}">
+              Enter a minimum confidence to route (0.0 and 1.0)</label>` +
+            `<input type="text" id="textInferenceIntentConfidence_${intent.intentName}" class="form-control" placeholder="Minimum confidence to route" value="${existingConfidence}">` +
+          `</div>` +
+        `</div>`;
+    });
+
+    var fallbackRuleSetName = loadedRule.params['intentRuleSet_FallbackIntent'];
+
+    html += `<hr><div class="row pb-1 px-3">` +
+          `<div class="col-4">FallbackIntent</div>` +
+          `<div class="col-8"><label for="textInferenceIntentRuleSet_FallbackIntent">Pick an optional target rule set for the FallbackIntent</label>` +
+            `<div class="row"><div class="col-11">` +
+              `<select class="selectpicker form-control" title="Choose a FallbackIntent rule set" data-style="btn-white" data-live-search="true" id="textInferenceIntentRuleSet_FallbackIntent">` +
+                `<option></option>`;
+
+              ruleSetsNames.forEach(rsn => {
+                if (rsn === fallbackRuleSetName)
+                {
+                  html += `<option selected>${rsn}</option>`;
+                }
+                else
+                {
+                  html += `<option>${rsn}</option>`;
+                }
+              });
+
+            html +=
+              `</select></div>` +
+              `<div class="col-1">` +
+                `<a href="javascript:viewRuleSet('#textInferenceIntentRuleSet_FallbackIntent');"><i class="fas fa-chevron-circle-right fa-lg text-primary mt-2"></i></a>` +
+              `</div></div>` +
+          `</div></div>`;
+
+    // No confidence for optional fallback ruleset routing
+
+    $('#textInferenceLexIntents').html(html);
+
+    $('.selectpicker').selectpicker();
+  }
+
+  async function loadIntentsNLUMenu(lexBotName)
   {
     $('#nluMenuLexIntents').html(`<div class="text-center"><img src="img/loading.gif" class="img-fluid" alt="Loading..."></div>`);
 

--- a/web/templates/configureRuleSet.hbs
+++ b/web/templates/configureRuleSet.hbs
@@ -1068,6 +1068,49 @@
           </div>
 
           <!--
+            TextInference
+          -->
+          <div id="CreateTextInferenceDiv" class="createDiv">
+            <p>
+              The TextInference rule inferences a LexV2 bot with text to determine
+              the next rule set. The intent must match with a minimum confidence or the rule
+              fall through to the next rule.
+            </p>
+            <p>
+              Input message is often source from the input transcript of previous Lex bot inferencing but may be sourced from anywhere in customer state.
+            </p>
+            <p>
+              You may also optionally match the FallbackIntent
+              for the bot in which case, intent match failures will always route to
+              the configured FallbackIntent this rule set.
+            </p>
+            <div class="form-group">
+              <label>Input message *</label>
+              <input type="text"
+                class="form-control"
+                id="textInferenceInput"
+                maxLength="1024"
+                placeholder="&#123;&#123;&#123;LexResponses.botname.inputTranscript&#125;&#125;&#125;"
+                value="&#123;&#123;&#123;LexResponses.botname.inputTranscript&#125;&#125;&#125;">
+              <small>Enter the text or template to inference against (usually obtained from a previous bot's input transcript)</small>
+            </div>
+            <div class="form-group">
+              <label>Lex bot *</label>
+              <select id="textInferenceLexBotName" title="Choose a bot" class="selectpicker form-control" data-style="btn-white" data-live-search="true">
+                {{#each lexBots}}
+                  <option>{{this.SimpleName}}</option>
+                {{/each}}
+              </select>
+              <small>The Lex bot to use for text inferencing</small>
+            </div>
+
+            <div class="form-group">
+              <label>Optionally choose a ruleset and intent confidence for each intent</label>
+              <div id="textInferenceLexIntents"></div>
+            </div>
+          </div>
+
+          <!--
             Terminate
           -->
           <div id="CreateTerminateDiv" class="createDiv">
@@ -1470,12 +1513,21 @@
   }
 
   /**
-   * Fired when the lex bot is changed
+   * Fired when the lex bot is changed in TextInference
+   */
+  $('#textInferenceLexBotName').on('change', function(e)
+  {
+    var lexBotName = $('#textInferenceLexBotName').val();
+    loadIntentsTextInference(lexBotName);
+  });
+
+  /**
+   * Fired when the lex bot is changed in NLUMenu
    */
   $('#nluMenuLexBotName').on('change', function(e)
   {
     var lexBotName = $('#nluMenuLexBotName').val();
-    loadIntents(lexBotName);
+    loadIntentsNLUMenu(lexBotName);
   });
 
   /**
@@ -1527,7 +1579,57 @@
     }
   });
 
-  async function loadIntents(lexBotName)
+  async function loadIntentsTextInference(lexBotName)
+  {
+    $('#textInferenceLexIntents').html(`<div class="text-center"><img src="img/loading.gif" class="img-fluid" alt="Loading..."></div>`);
+
+    currentBot = await describeLexBot(lexBotName);
+
+    var html = '';
+
+    currentBot.intents.forEach(intent => {
+
+      html +=
+        `<hr><div class="row pb-1 px-3">` +
+          `<div class="col-4">${intent.intentName}</div>` +
+          `<div class="col-8"><label for="textInferenceIntentRuleSet_${intent.intentName}">Pick an optional target rule set</label>` +
+            `<select class="selectpicker form-control" title="Choose a rule set" data-style="btn-white" data-live-search="true" id="textInferenceIntentRuleSet_${intent.intentName}">` +
+              `<option></option>`;
+
+              ruleSetsNames.forEach(rsn => {
+                html += `<option>${rsn}</option>`;
+              });
+
+          html +=
+            `</select>` +
+            `<label class="pt-2" for="textInferenceIntentConfidence_${intent.intentName}">
+              Enter a minimum confidence to route (0.0 and 1.0)</label>` +
+            `<input type="text" id="textInferenceIntentConfidence_${intent.intentName}" class="form-control" placeholder="Minimum confidence to route" value="1.0">` +
+          `</div>` +
+        `</div>`;
+    });
+
+    html += `<hr><div class="row pb-1 px-3">` +
+          `<div class="col-4">FallbackIntent</div>` +
+          `<div class="col-8"><label for="textInferenceIntentRuleSet_FallbackIntent">Pick an optional target rule set for the FallbackIntent</label>` +
+            `<select class="selectpicker form-control" title="Choose a FallbackIntent rule set" data-style="btn-white" data-live-search="true" id="textInferenceIntentRuleSet_FallbackIntent">` +
+              `<option></option>`;
+
+              ruleSetsNames.forEach(rsn => {
+                html += `<option>${rsn}</option>`;
+              });
+
+          html +=
+            `</select>` +
+          `</div>` +
+        `</div>`;
+
+    $('#textInferenceLexIntents').html(html);
+
+    $('.selectpicker').selectpicker();
+  }
+
+  async function loadIntentsNLUMenu(lexBotName)
   {
     $('#nluMenuLexIntents').html(`<div class="text-center"><img src="img/loading.gif" class="img-fluid" alt="Loading..."></div>`);
 
@@ -2627,6 +2729,74 @@
       }
 
       params.updateStates = updateStatesAttributes;
+    }
+
+    /**
+     * TextInference
+     */
+    if (ruleType === 'TextInference')
+    {
+      if (currentBot === undefined)
+      {
+        alert('No bot was loaded');
+        return;
+      }
+
+      var botName = $('#textInferenceLexBotName').val().trim();
+      var input = $('#textInferenceInput').val().trim();
+
+      if (botName === '')
+      {
+        alert('Please select a lex bot');
+        return;
+      }
+
+      if (input === '')
+      {
+        alert('Please enter an input message template');
+        return;
+      }
+
+      params.input = input;
+      params.lexBotName = currentBot.botName;
+      var intentCount = 0;
+
+      // Check each intent has a rule set and a confirmation message
+      for (var intentIndex = 0; intentIndex < currentBot.intents.length; intentIndex++)
+      {
+        var intent = currentBot.intents[intentIndex];
+
+        var ruleSetName = $(`#textInferenceIntentRuleSet_${intent.intentName}`).val().trim();
+        var confidence = $(`#textInferenceIntentConfidence_${intent.intentName}`).val().trim();
+
+        if (ruleSetName !== '')
+        {
+          if (confidence === '' ||
+             !isNumber(confidence) ||
+             +confidence < 0.0 ||
+             +confidence > 1.0)
+          {
+            alert(`Please enter a valid confidence for intent: ${intent.intentName} between 0.0 and 1.0`);
+            return;
+          }
+
+          params[`intentRuleSet_${intent.intentName}`] = ruleSetName;
+          params[`intentConfidence_${intent.intentName}`] = confidence;
+          intentCount++;
+        }
+      }
+
+      var fallBackIntentRuleSet = $(`#textInferenceIntentRuleSet_FallbackIntent`).val().trim();
+
+      if (fallBackIntentRuleSet !== '')
+      {
+        params[`intentRuleSet_FallbackIntent`] = fallBackIntentRuleSet;
+        intentCount++;
+      }
+
+      params.intentCount = '' + intentCount;
+
+      console.log('[INFO] made TextInference params: ' + JSON.stringify(params, null, 2));
     }
 
     var weights = [];


### PR DESCRIPTION
Rule UI for text inference with interactive component and some unit testing

- TODO implement connect rules inference for text inference
- TODO beef up unit testing for text inference interactive

*Issue #, if available:*

Customer wants to be able to feed the raw transcript from a previous inference into a more specific lex bot without customer interaction, TextInference provides this capability.

*Description of changes:*

New TextInteractive rule which provides text based inferencing capabilities, initially in interactive with connect side to fast follow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
