### PR TITLE
Added additonal backoff sleep for loading queues for a routing profile

### DIFF
--- a/lambda/utils/ConnectUtils.js
+++ b/lambda/utils/ConnectUtils.js
@@ -385,6 +385,8 @@ module.exports.describeRoutingProfiles = async function(instanceId)
           routingProfileList[i].Queues.push(queue);
         });
       }
+
+      await commonUtils.sleep(500);
     }
 
     return routingProfileList;


### PR DESCRIPTION
*Description of changes:*

Adds an additional sleep while describing routing profiles to fix cache refresh throttling issues for customers with large numbers of routing profiles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
