### PR TITLE
Bugfix/alternatecallbacknumber

### DIFF
--- a/lambda/ConnectCreateCallback.js
+++ b/lambda/ConnectCreateCallback.js
@@ -1,49 +1,70 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-var requestUtils = require('./utils/RequestUtils.js');
-var dynamoUtils = require('./utils/DynamoUtils.js');
+var requestUtils = require("./utils/RequestUtils.js");
+var dynamoUtils = require("./utils/DynamoUtils.js");
 
 /**
  * Creates a callback in DynamoDB
  */
-exports.handler = async (event, context) =>
-{
-  try
-  {
+exports.handler = async (event, context) => {
+  try {
     requestUtils.logRequest(event);
 
     var contactId = event.Details.ContactData.InitialContactId;
 
     // Load customer state
-    var customerState = await dynamoUtils.getParsedCustomerState(process.env.STATE_TABLE, contactId);
+    var customerState = await dynamoUtils.getParsedCustomerState(
+      process.env.STATE_TABLE,
+      contactId
+    );
 
-    requestUtils.requireParameter('phoneNumber', event.Details.Parameters.phoneNumber);
-    requestUtils.requireParameter('queueArn', customerState.CurrentRule_queueArn);
+    requestUtils.requireParameter(
+      "phoneNumber",
+      event.Details.Parameters.phoneNumber
+    );
+    requestUtils.requireParameter(
+      "queueArn",
+      customerState.CurrentRule_queueArn
+    );
 
     var phoneNumber = event.Details.Parameters.phoneNumber;
     var queueArn = customerState.CurrentRule_queueArn;
 
     //check if callback exists
-    var phoneNumberInAnyCallbackQueue = await dynamoUtils.phoneNumberInAnyCallbackQueue(process.env.CALLBACK_TABLE, phoneNumber);
+    var phoneNumberInAnyCallbackQueue =
+      await dynamoUtils.phoneNumberInAnyCallbackQueue(
+        process.env.CALLBACK_TABLE,
+        phoneNumber
+      );
 
-    if (phoneNumberInAnyCallbackQueue)
-    {
-      customerState.CurrentRule_CreateCallbackStatus = 'EXISTING';
-      await dynamoUtils.persistCustomerState(process.env.STATE_TABLE, contactId, customerState, ['CurrentRule_CreateCallbackStatus']);
+    if (phoneNumberInAnyCallbackQueue) {
+      customerState.CurrentRule_CreateCallbackStatus = "EXISTING";
+      await dynamoUtils.persistCustomerState(
+        process.env.STATE_TABLE,
+        contactId,
+        customerState,
+        ["CurrentRule_CreateCallbackStatus"]
+      );
+      return requestUtils.buildCustomerStateResponse(customerState);
+    } else {
+      await dynamoUtils.insertCallback(
+        process.env.CALLBACK_TABLE,
+        phoneNumber,
+        queueArn
+      );
+      customerState.CurrentRule_CreateCallbackStatus = "CREATED";
+      customerState.AlternateCallbackPhoneNumber = phoneNumber;
+      await dynamoUtils.persistCustomerState(
+        process.env.STATE_TABLE,
+        contactId,
+        customerState,
+        ["CurrentRule_CreateCallbackStatus", "AlternateCallbackPhoneNumber"]
+      );
       return requestUtils.buildCustomerStateResponse(customerState);
     }
-    else
-    {
-      await dynamoUtils.insertCallback(process.env.CALLBACK_TABLE, phoneNumber, queueArn);
-      customerState.CurrentRule_CreateCallbackStatus = 'CREATED';
-      await dynamoUtils.persistCustomerState(process.env.STATE_TABLE, contactId, customerState, ['CurrentRule_CreateCallbackStatus']);
-      return requestUtils.buildCustomerStateResponse(customerState);
-    }
-  }
-  catch (error)
-  {
-    console.log('[ERROR] Failed to create callback', error);
+  } catch (error) {
+    console.log("[ERROR] Failed to create callback", error);
     throw error;
   }
 };

--- a/lambda/ConnectCreateCallback.js
+++ b/lambda/ConnectCreateCallback.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-var requestUtils = require("./utils/RequestUtils.js");
-var dynamoUtils = require("./utils/DynamoUtils.js");
+var requestUtils = require('./utils/RequestUtils.js');
+var dynamoUtils = require('./utils/DynamoUtils.js');
 
 /**
  * Creates a callback in DynamoDB
@@ -14,57 +14,30 @@ exports.handler = async (event, context) => {
     var contactId = event.Details.ContactData.InitialContactId;
 
     // Load customer state
-    var customerState = await dynamoUtils.getParsedCustomerState(
-      process.env.STATE_TABLE,
-      contactId
-    );
+    var customerState = await dynamoUtils.getParsedCustomerState(process.env.STATE_TABLE, contactId);
 
-    requestUtils.requireParameter(
-      "phoneNumber",
-      event.Details.Parameters.phoneNumber
-    );
-    requestUtils.requireParameter(
-      "queueArn",
-      customerState.CurrentRule_queueArn
-    );
+    requestUtils.requireParameter('phoneNumber', event.Details.Parameters.phoneNumber);
+    requestUtils.requireParameter('queueArn', customerState.CurrentRule_queueArn);
 
     var phoneNumber = event.Details.Parameters.phoneNumber;
     var queueArn = customerState.CurrentRule_queueArn;
 
     //check if callback exists
-    var phoneNumberInAnyCallbackQueue =
-      await dynamoUtils.phoneNumberInAnyCallbackQueue(
-        process.env.CALLBACK_TABLE,
-        phoneNumber
-      );
+    var phoneNumberInAnyCallbackQueue = await dynamoUtils.phoneNumberInAnyCallbackQueue(process.env.CALLBACK_TABLE, phoneNumber);
 
     if (phoneNumberInAnyCallbackQueue) {
-      customerState.CurrentRule_CreateCallbackStatus = "EXISTING";
-      await dynamoUtils.persistCustomerState(
-        process.env.STATE_TABLE,
-        contactId,
-        customerState,
-        ["CurrentRule_CreateCallbackStatus"]
-      );
+      customerState.CurrentRule_CreateCallbackStatus = 'EXISTING';
+      await dynamoUtils.persistCustomerState(process.env.STATE_TABLE, contactId, customerState, ['CurrentRule_CreateCallbackStatus']);
       return requestUtils.buildCustomerStateResponse(customerState);
     } else {
-      await dynamoUtils.insertCallback(
-        process.env.CALLBACK_TABLE,
-        phoneNumber,
-        queueArn
-      );
-      customerState.CurrentRule_CreateCallbackStatus = "CREATED";
+      await dynamoUtils.insertCallback(process.env.CALLBACK_TABLE, phoneNumber, queueArn);
+      customerState.CurrentRule_CreateCallbackStatus = 'CREATED';
       customerState.AlternateCallbackPhoneNumber = phoneNumber;
-      await dynamoUtils.persistCustomerState(
-        process.env.STATE_TABLE,
-        contactId,
-        customerState,
-        ["CurrentRule_CreateCallbackStatus", "AlternateCallbackPhoneNumber"]
-      );
+      await dynamoUtils.persistCustomerState(process.env.STATE_TABLE, contactId, customerState, ['CurrentRule_CreateCallbackStatus', 'AlternateCallbackPhoneNumber']);
       return requestUtils.buildCustomerStateResponse(customerState);
     }
   } catch (error) {
-    console.log("[ERROR] Failed to create callback", error);
+    console.log('[ERROR] Failed to create callback', error);
     throw error;
   }
 };

--- a/lambda/ConnectDeleteCallback.js
+++ b/lambda/ConnectDeleteCallback.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-var requestUtils = require("./utils/RequestUtils.js");
-var dynamoUtils = require("./utils/DynamoUtils.js");
+var requestUtils = require('./utils/RequestUtils.js');
+var dynamoUtils = require('./utils/DynamoUtils.js');
 
 /**
  * Deletes a callback from DynamoDB
@@ -11,13 +11,10 @@ exports.handler = async (event, context) => {
   try {
     var contactId = event.Details.ContactData.InitialContactId;
 
-    requestUtils.requireParameter("ContactId", contactId);
+    requestUtils.requireParameter('ContactId', contactId);
 
     //load customer state
-    var customerState = await dynamoUtils.getParsedCustomerState(
-      process.env.STATE_TABLE,
-      contactId
-    );
+    var customerState = await dynamoUtils.getParsedCustomerState(process.env.STATE_TABLE, contactId);
 
     if (customerState.AlternateCallbackPhoneNumber) {
       var phoneNumber = customerState.AlternateCallbackPhoneNumber;
@@ -28,26 +25,20 @@ exports.handler = async (event, context) => {
     var queueArn = customerState.CurrentRule_queueArn;
 
     if (phoneNumber === undefined) {
-      throw new Error("Missing required parameter: phoneNumber");
+      throw new Error('Missing required parameter: phoneNumber');
     }
 
     if (queueArn === undefined) {
-      throw new Error("Missing required parameter: queueArn");
+      throw new Error('Missing required parameter: queueArn');
     }
 
-    console.log(
-      `[INFO] Deleting callback for ${phoneNumber} on queue ${queueArn}`
-    );
+    console.log(`[INFO] Deleting callback for ${phoneNumber} on queue ${queueArn}`);
 
-    await dynamoUtils.deleteCallback(
-      process.env.CALLBACK_TABLE,
-      phoneNumber,
-      queueArn
-    );
+    await dynamoUtils.deleteCallback(process.env.CALLBACK_TABLE, phoneNumber, queueArn);
 
     return requestUtils.buildCustomerStateResponse(customerState);
   } catch (error) {
-    console.log("[ERROR] Failed to delete callback", error);
+    console.log('[ERROR] Failed to delete callback', error);
     throw error;
   }
 };

--- a/lambda/ConnectDeleteCallback.js
+++ b/lambda/ConnectDeleteCallback.js
@@ -1,42 +1,53 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-var requestUtils = require('./utils/RequestUtils.js');
-var dynamoUtils = require('./utils/DynamoUtils.js');
+var requestUtils = require("./utils/RequestUtils.js");
+var dynamoUtils = require("./utils/DynamoUtils.js");
 
 /**
  * Deletes a callback from DynamoDB
  */
-exports.handler = async (event, context) =>
-{
-  try
-  {
+exports.handler = async (event, context) => {
+  try {
     var contactId = event.Details.ContactData.InitialContactId;
 
-    requestUtils.requireParameter('ContactId', contactId);
+    requestUtils.requireParameter("ContactId", contactId);
 
     //load customer state
-    var customerState = await dynamoUtils.getParsedCustomerState(process.env.STATE_TABLE, contactId);
+    var customerState = await dynamoUtils.getParsedCustomerState(
+      process.env.STATE_TABLE,
+      contactId
+    );
 
-    var phoneNumber = customerState.OriginalCustomerNumber;
+    if (customerState.AlternateCallbackPhoneNumber) {
+      var phoneNumber = customerState.AlternateCallbackPhoneNumber;
+    } else {
+      var phoneNumber = customerState.OriginalCustomerNumber;
+    }
+
     var queueArn = customerState.CurrentRule_queueArn;
 
     if (phoneNumber === undefined) {
-      throw new Error('Missing required parameter: phoneNumber');
+      throw new Error("Missing required parameter: phoneNumber");
     }
 
     if (queueArn === undefined) {
-      throw new Error('Missing required parameter: queueArn');
+      throw new Error("Missing required parameter: queueArn");
     }
 
-    console.log(`[INFO] Deleting callback for ${phoneNumber} on queue ${queueArn}`);
+    console.log(
+      `[INFO] Deleting callback for ${phoneNumber} on queue ${queueArn}`
+    );
 
-    await dynamoUtils.deleteCallback(process.env.CALLBACK_TABLE, phoneNumber, queueArn);
+    await dynamoUtils.deleteCallback(
+      process.env.CALLBACK_TABLE,
+      phoneNumber,
+      queueArn
+    );
 
     return requestUtils.buildCustomerStateResponse(customerState);
-  }
-  catch (error) {
-    console.log('[ERROR] Failed to delete callback', error);
+  } catch (error) {
+    console.log("[ERROR] Failed to delete callback", error);
     throw error;
   }
 };


### PR DESCRIPTION
*Issue https://github.com/aws-samples/amazon-connect-rules-engine/issues/29 

*Description of changes:*
- Update ConnectCreateCallback function to add AlternativeCallbackPhoneNumber value to Initial ContactId containing Alternative Callback Phone Number
- Update ConnectDeleteCallback function to set phoneNumber variable to equal  customerState.AlternateCallbackPhoneNumber if it exists so dynamoUtils.deleteCallback works as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
