### PR TITLE
Fix to support SSML in error messages which broke interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,3 +178,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ConnectRulesIntegration removed debug error messages from contact flow
 - Delete holiday via DeleteObject now sets the last updated timestamp
 
+## [3.0.20] - 2022-10-11
+
+### Fixed
+
+- Added support for mixed SSML error messages in input and menu controls in interactive
+

--- a/lambda/interactive/DTMFInput.js
+++ b/lambda/interactive/DTMFInput.js
@@ -251,7 +251,7 @@ module.exports.input = async (context) =>
       {
         console.error('DTMFInput.input() prompting the customer for input again');
 
-        errorMessage += '\n' + context.customerState.CurrentRule_offerMessage;
+        errorMessage = commonUtils.safelyMergePrompts([errorMessage, context.customerState.CurrentRule_offerMessage]);
 
         return {
           contactId: context.requestMessage.contactId,

--- a/lambda/interactive/DTMFMenu.js
+++ b/lambda/interactive/DTMFMenu.js
@@ -156,7 +156,7 @@ module.exports.input = async (context) =>
       {
         console.info('DTMFMenu.input() prompting the customer for input again');
 
-        errorMessage += '\n' + context.customerState.CurrentRule_offerMessage;
+        errorMessage = commonUtils.safelyMergePrompts([errorMessage, context.customerState.CurrentRule_offerMessage]);
 
         return {
           contactId: context.requestMessage.contactId,

--- a/lambda/interactive/NLUInput.js
+++ b/lambda/interactive/NLUInput.js
@@ -277,7 +277,7 @@ module.exports.input = async (context) =>
       {
         console.info('NLUInput.input() prompting the customer for input again');
 
-        errorMessage += '\n' + context.customerState.CurrentRule_offerMessage;
+        errorMessage = commonUtils.safelyMergePrompts([errorMessage, context.customerState.CurrentRule_offerMessage]);
 
         return {
           contactId: context.requestMessage.contactId,

--- a/lambda/interactive/NLUMenu.js
+++ b/lambda/interactive/NLUMenu.js
@@ -226,7 +226,7 @@ module.exports.input = async (context) =>
       {
         console.info('NLUMenu.input() prompting the customer for input again');
 
-        errorMessage += '\n' + context.customerState.CurrentRule_offerMessage;
+        errorMessage = commonUtils.safelyMergePrompts([errorMessage, context.customerState.CurrentRule_offerMessage]);
 
         return {
           contactId: context.requestMessage.contactId,

--- a/lambda/utils/CommonUtils.js
+++ b/lambda/utils/CommonUtils.js
@@ -68,3 +68,65 @@ module.exports.clone = (object) =>
 {
   return JSON.parse(JSON.stringify(object));
 };
+
+/**
+ * Safely merges an array of prompts, handling one or more being SSML
+ */
+module.exports.safelyMergePrompts = (promptsArray) =>
+{
+  var hasSSML = false;
+
+  promptsArray.forEach(prompt =>
+  {
+    if (module.exports.isSSML(prompt))
+    {
+      hasSSML = true;
+    }
+  });
+
+  var outputPrompt = '';
+
+  if (hasSSML)
+  {
+    outputPrompt += '<speak>';
+  }
+
+  promptsArray.forEach(prompt =>
+  {
+    outputPrompt += `\n${module.exports.stripSSMLWrapper(prompt)}`;
+  });
+
+  if (hasSSML)
+  {
+    outputPrompt += '\n</speak>';
+  }
+
+  outputPrompt = outputPrompt.trim();
+
+  return outputPrompt;
+}
+
+
+/**
+ * Checks to see if this is an SSML tag
+ */
+module.exports.isSSML = (prompt) =>
+{
+  var trimmed = prompt.trim();
+  return trimmed === '<speak/>' || (trimmed.startsWith('<speak>') && trimmed.endsWith('</speak>'));
+}
+
+/**
+ * Strips wrapper speak tags
+ */
+module.exports.stripSSMLWrapper = (prompt) =>
+{
+  if (module.exports.isSSML(prompt))
+  {
+    return prompt.replace('<speak>', '').replace('</speak>', '').trim();
+  }
+  else
+  {
+    return prompt;
+  }
+}

--- a/lambda/utils/PollyUtils.js
+++ b/lambda/utils/PollyUtils.js
@@ -50,4 +50,3 @@ module.exports.synthesizeVoice = async (text, voiceId = 'Olivia', languageCode =
     throw error;
   }
 };
-

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -27,7 +27,7 @@ custom:
   instanceArn: ${env:instanceArn, 'CHANGEME'}
   outboundNumber: ${env:outboundNumber, 'CHANGEME'}
   environmentName: ${env:environmentName, 'Unknown'}
-  deployVersion: ${env:deployVersion, '3.0.19 (DTMFInput confirmation handling)'}
+  deployVersion: ${env:deployVersion, '3.0.20 (SSML error message support)'}
   callCentreTimeZone: ${env:callCentreTimeZone, 'Australia/Melbourne'}
   botAlias: ${env:botAlias, 'PROD'}
   botLocaleId: ${env:botLocaleId, 'en_AU'}

--- a/test/CommonUtilsTest.js
+++ b/test/CommonUtilsTest.js
@@ -101,4 +101,24 @@ describe('CommonUtilsTests', function()
     expect(foo.sneh).to.equal('bar');
   });
 
+  it('CommonUtils.safelyMergePrompts() tests', async function()
+  {
+    var merged = commonUtils.safelyMergePrompts(['prompt1', 'prompt2']);
+
+    expect(merged).to.equal('prompt1\nprompt2');
+
+    merged = commonUtils.safelyMergePrompts(['<speak>prompt1</speak>', 'prompt2']);
+
+    expect(merged).to.equal('<speak>\nprompt1\nprompt2\n</speak>');
+
+    merged = commonUtils.safelyMergePrompts(['prompt1', ' <speak> prompt2 </speak> ']);
+
+    expect(merged).to.equal('<speak>\nprompt1\nprompt2\n</speak>');
+
+    merged = commonUtils.safelyMergePrompts(['<speak>Hey<break time="5s"/>there</speak>', ' <speak> prompt2 </speak> ']);
+
+    expect(merged).to.equal('<speak>\nHey<break time="5s"/>there\nprompt2\n</speak>');
+
+  });
+
 });


### PR DESCRIPTION
Fix to support SSML in error messages which broke interactive when merging error prompt and offer messages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
